### PR TITLE
Expose e-mail template ID as env var

### DIFF
--- a/src/locations/signals.py
+++ b/src/locations/signals.py
@@ -25,7 +25,7 @@ def on_community_proposal(**kwargs):
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[settings.SUPERADMIN_CONTACT_EMAIL],
     )
-    email.template_id = "d-9a97252feff540d0b026edb02945f8d9"
+    email.template_id = settings.EMAIL_TEMPLATE_ID
     email.merge_global_data = tpl_data
     try_send_email(email)
 

--- a/src/map_kit/settings.py
+++ b/src/map_kit/settings.py
@@ -252,3 +252,4 @@ SUPERADMIN_CONTACT_EMAIL = os.environ.get(
 DEFAULT_FROM_EMAIL = os.environ.get(
     "DEFAULT_FROM_EMAIL", "Harta Diasporei <info@hartadiasporei.org>"
 )
+EMAIL_TEMPLATE_ID = os.environ.get("EMAIL_TEMPLATE_ID")


### PR DESCRIPTION
This ID should ideally not be hard coded, so this PR moves it to settings.