### PR TITLE
Pass Mapbox token into container

### DIFF
--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -20,6 +20,8 @@ jobs:
       run: source .env
 
     - name: Build the docker-compose stack
+      env:
+        MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
       run: docker-compose up -d
 
     - name: Run migrations

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ We use Auth0 because it makes managing multiple authentication providers (Google
 ### Set-up
 
 1. Adjust Auth0 variables (prefixed `OIDC_`) in .env.
+2. Use an exising [Mapbox](https://account.mapbox.com/) token or create a new one, and add it as `MAPBOX_TOKEN` to .env.
 2. Build your containers again.
 
 **TODO**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
             - DJANGO_SETTINGS_MODULE
             - DJANGO_EMAIL_BACKEND
             - SENDGRID_API_KEY
+            - MAPBOX_TOKEN
             - OIDC_RP_CLIENT_ID
             - OIDC_RP_CLIENT_SECRET
             - OIDC_OP_JWKS_ENDPOINT


### PR DESCRIPTION
Attempting a workaround for https://github.com/dcberlin/map-kit-backend/issues/44 by switching from OSM Nominatim API to Mapbox API for geocoding in CI.

The downside is that this will still fail when the token is not set locally. If we can live with the Mapbox token being required for local setups for now, then this approach should do, to unblock CI. A sustainable solution would entail finding a way to geocode locally and in CI without a third party API with authentication: One could for example use the Nominatim docker image to spin up a server in the docker compose stack and use that. It would incur a high cost in terms of CI duration though, to pull that image and spin it up.