### PR TITLE
Reduce Sentry trace sampling rate to 1%

### DIFF
--- a/src/map_kit/settings.py
+++ b/src/map_kit/settings.py
@@ -26,7 +26,7 @@ if SENTRY_DSN := os.environ.get("SENTRY_DSN", None):
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.01,
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=True,


### PR DESCRIPTION
This should help prevent exceeding monthly usage thresholds to early. Addresses #48 