### PR TITLE
Try fixing the health endpoint filtering

### DIFF
--- a/src/map_kit/settings.py
+++ b/src/map_kit/settings.py
@@ -23,11 +23,7 @@ def trace_sampler(sampling_context):
     Sets custom trace sample rates for different transactions.
     For now it filters out the health endpoint.
     """
-    if (
-        sampling_context.get("transaction_context", {})
-        .get("name", "")
-        .endswith("/health/")
-    ):
+    if sampling_context.get("name", "").endswith("/health/"):
         return 0.0
 
     return 1.0


### PR DESCRIPTION
The current approach does not succeed in filtering the health endpoint transactions in Sentry. This PR tries to address that.
